### PR TITLE
feat: Introducing Error/Success Messages without Redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,70 +211,50 @@ export const action = () => {
 
 ### jsonWithSuccess
 
-Show a success toast message without a redirection
+Display a success toast message without a redirection.
 
 ```tsx
 import { jsonWithSuccess } from "remix-toast";
 
 export const action = () => {
-  // The empty object passed as the first argument can be used
-  // to include additional data to be returned along with the success message.
-  return jsonWithSuccess({},"Operation successful! 🎉");
+  return jsonWithSuccess({ result: "Data saved successfully" }, "Operation successful! 🎉");
 };
-```
-
-You can do more actions on the client side once the `toast` is received from the action
-
-```tsx
-export default function YourRoute() {
-  const actionData = useActionData<typeof action>();
-  // Hook to show the toasts
-  useEffect(() => {
-    if (actionData) {
-      if ("toast" in actionData) {
-        //Do something
-      }
-    }
-  }, [actionData]);
-
-  return (
-// the rest of your code
-  );
-}
 ```
 
 ### jsonWithError
 
-Show an error toast message without a redirection
+Display an error toast message without a redirection.
 
 ```tsx
 import { jsonWithError } from "remix-toast";
 
 export const action = () => {
-  // The empty object passed as the first argument can be used
-  // to include additional data to be returned along with the error message.
-  return jsonWithError({},"Oops! Something went wrong. Please try again later.");
+  return jsonWithError(null, "Oops! Something went wrong. Please try again later.");
 };
 ```
 
-You can do more actions on the client side once the `toast` is received from the action
+### jsonWithInfo
+
+Display an info toast message without a redirection.
 
 ```tsx
-export default function YourRoute() {
-  const actionData = useActionData<typeof action>();
-  // Hook to show the toasts
-  useEffect(() => {
-    if (actionData) {
-      if ("toast" in actionData) {
-        //Do something
-      }
-    }
-  }, [actionData]);
+import { jsonWithInfo } from "remix-toast";
 
-  return (
-// the rest of your code
-  );
-}
+export const action = () => {
+  return jsonWithInfo({ info: "Additional information" }, "Your profile has been successfully updated.");
+};
+```
+
+### jsonWithWarning
+
+Display a warning toast message without a redirection.
+
+```tsx
+import { jsonWithWarning } from "remix-toast";
+
+export const action = () => {
+  return jsonWithWarning({ warning: "Potential issues" }, "Your session is about to expire.");
+};
 ```
 
 # Thank you

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ library is server agnostic and should work with any server setup.
 
 If you wish to read an in depth explanation of how this works you can find it here:
 https://alemtuzlak.hashnode.dev/handling-toasts-in-remix
-
-
-
 ## Installation
 
 ```bash
@@ -101,7 +98,6 @@ export default function App() {
     </html>
   );
 }
-
 ```
 
 ![react-toastify](./assets/react-toastify.gif) 
@@ -113,8 +109,8 @@ import { json, type LinksFunction, type LoaderFunctionArgs } from "@remix-run/no
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
 import { useEffect } from "react";
 import { getToast } from "remix-toast";
-import { Toaster, toast as notify } from "sonner"; 
- 
+import { Toaster, toast as notify } from "sonner";
+
 // Implemented from above
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { toast, headers } = await getToast(request);
@@ -124,7 +120,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 export default function App() {
   const { toast } = useLoaderData<typeof loader>();
   // Hook to show the toasts
-   useEffect(() => {
+  useEffect(() => {
     if (toast?.type === "error") {
       notify.error(toast.message);
     }
@@ -135,9 +131,7 @@ export default function App() {
 
   return (
     <html lang="en">
-      <head>
-        ...
-      </head>
+      <head>...</head>
       <body>
         ...
         {/* Add the toast container */}
@@ -146,7 +140,6 @@ export default function App() {
     </html>
   );
 }
-
 ```
 
 ![react-toastify](./assets/sonner.gif) 
@@ -184,7 +177,6 @@ export const action = () => {
 Redirects to a new route and shows an error toast message.
 
 ```tsx
-
 import { redirectWithError } from "remix-toast";
 
 export const action = () => {
@@ -202,8 +194,7 @@ import { redirectWithInfo } from "remix-toast";
 
 export const action = () => {
   return redirectWithInfo("/login", "You need to login to access this page");
-}
-
+};
 ```
 
 ### redirectWithWarning
@@ -211,17 +202,78 @@ export const action = () => {
 Redirects to a new route and shows a warning toast message.
 
 ```tsx
-
 import { redirectWithWarning } from "remix-toast";
 
 export const action = () => {
   return redirectWithWarning("/login", "You need to login to access this page");
-}
+};
+```
 
+### displaySuccessMessage
+
+Show a success toast message without a redirection
+
+```tsx
+import { displaySuccessMessage } from "remix-toast";
+
+export const action = () => {
+  return displaySuccessMessage("Operation successful! 🎉");
+};
+```
+
+You can do more actions on the client side once the `successMessage` is received from the action
+
+```tsx
+export default function YourRoute() {
+  const actionData = useActionData<typeof action>();
+  // Hook to show the toasts
+  useEffect(() => {
+    if (actionData) {
+      if ("successMessage" in actionData) {
+        //Do something
+      }
+    }
+  }, [actionData]);
+
+  return (
+// the rest of your code
+  );
+}
+```
+
+### displayErrorMessage
+
+Show an error toast message without a redirection
+
+```tsx
+import { displayErrorMessage } from "remix-toast";
+
+export const action = () => {
+  return displayErrorMessage("Oops! Something went wrong. Please try again later.");
+};
+```
+
+You can do more actions on the client side once the `errorMessage` is received from the action
+
+```tsx
+export default function YourRoute() {
+  const actionData = useActionData<typeof action>();
+  // Hook to show the toasts
+  useEffect(() => {
+    if (actionData) {
+      if ("errorMessage" in actionData) {
+        //Do something
+      }
+    }
+  }, [actionData]);
+
+  return (
+// the rest of your code
+  );
+}
 ```
 
 # Thank you
-
 
 If you wish to support this project you can do so by starring this repository and sharing it with your friends.
 

--- a/README.md
+++ b/README.md
@@ -209,19 +209,21 @@ export const action = () => {
 };
 ```
 
-### displaySuccessMessage
+### jsonWithSuccess
 
 Show a success toast message without a redirection
 
 ```tsx
-import { displaySuccessMessage } from "remix-toast";
+import { jsonWithSuccess } from "remix-toast";
 
 export const action = () => {
-  return displaySuccessMessage("Operation successful! 🎉");
+  // The empty object passed as the first argument can be used
+  // to include additional data to be returned along with the success message.
+  return jsonWithSuccess({},"Operation successful! 🎉");
 };
 ```
 
-You can do more actions on the client side once the `successMessage` is received from the action
+You can do more actions on the client side once the `toast` is received from the action
 
 ```tsx
 export default function YourRoute() {
@@ -229,7 +231,7 @@ export default function YourRoute() {
   // Hook to show the toasts
   useEffect(() => {
     if (actionData) {
-      if ("successMessage" in actionData) {
+      if ("toast" in actionData) {
         //Do something
       }
     }
@@ -241,19 +243,21 @@ export default function YourRoute() {
 }
 ```
 
-### displayErrorMessage
+### jsonWithError
 
 Show an error toast message without a redirection
 
 ```tsx
-import { displayErrorMessage } from "remix-toast";
+import { jsonWithError } from "remix-toast";
 
 export const action = () => {
-  return displayErrorMessage("Oops! Something went wrong. Please try again later.");
+  // The empty object passed as the first argument can be used
+  // to include additional data to be returned along with the error message.
+  return jsonWithError({},"Oops! Something went wrong. Please try again later.");
 };
 ```
 
-You can do more actions on the client side once the `errorMessage` is received from the action
+You can do more actions on the client side once the `toast` is received from the action
 
 ```tsx
 export default function YourRoute() {
@@ -261,7 +265,7 @@ export default function YourRoute() {
   // Hook to show the toasts
   useEffect(() => {
     if (actionData) {
-      if ("errorMessage" in actionData) {
+      if ("toast" in actionData) {
         //Do something
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,15 +40,18 @@ async function redirectWithFlash(url: string, flash: FlashSessionValues, init?: 
  * Helper method used to display a success toast notification without redirection
  *
  * It need to be awaited
- * @param successMessage Message to be shown as success
- * @returns Returns successMessage and a toast cookie set
+ * @param passedInData Generic object containing the data
+ * @param toast Message to be shown as success
+ * @param init Additional response options (status code, additional headers etc)
+ * @returns Returns data and a toast cookie set
  */
-export async function displaySuccessMessage(successMessage: string) {
+export async function jsonWithSuccess<T>(passedInData: T, toast: string, init?: ResponseInit) {
   return json(
-    { successMessage },
+    { ...passedInData, toast },
     {
+      ...init,
       headers: await flashMessage({
-        toast: { message: successMessage, type: "success" },
+        toast: { message: toast, type: "success" },
       }),
     },
   );
@@ -57,15 +60,18 @@ export async function displaySuccessMessage(successMessage: string) {
  * Helper method used to display an error toast notification without redirection
  *
  * It need to be awaited
- * @param errorMessage Message to be shown as success
- * @returns Returns errorMessage and a toast cookie set
+ * @param passedInData Generic object containing the data
+ * @param toast Message to be shown as error
+ * @param init Additional response options (status code, additional headers etc)
+ * @returns Returns data and a toast cookie set
  */
-export async function displayErrorMessage(errorMessage: string) {
+export async function jsonWithError<T>(passedInData: T, toast: string, init?: ResponseInit) {
   return json(
-    { errorMessage },
+    { ...passedInData, toast },
     {
+      ...init,
       headers: await flashMessage({
-        toast: { message: errorMessage, type: "error" },
+        toast: { message: toast, type: "error" },
       }),
     },
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorageFactory, createCookieFactory, redirect } from "@remix-run/server-runtime";
+import { createCookieSessionStorageFactory, createCookieFactory, redirect, json } from "@remix-run/server-runtime";
 import { FlashSessionValues, ToastMessage, flashSessionValuesSchema } from "./schema";
 import { sign, unsign } from "./crypto";
 
@@ -36,6 +36,40 @@ async function redirectWithFlash(url: string, flash: FlashSessionValues, init?: 
   });
 }
 
+/**
+ * Helper method used to display a success toast notification without redirection
+ *
+ * It need to be awaited
+ * @param successMessage Message to be shown as success
+ * @returns Returns successMessage and a toast cookie set
+ */
+export async function displaySuccessMessage(successMessage: string) {
+  return json(
+    { successMessage },
+    {
+      headers: await flashMessage({
+        toast: { message: successMessage, type: "success" },
+      }),
+    },
+  );
+}
+/**
+ * Helper method used to display an error toast notification without redirection
+ *
+ * It need to be awaited
+ * @param errorMessage Message to be shown as success
+ * @returns Returns errorMessage and a toast cookie set
+ */
+export async function displayErrorMessage(errorMessage: string) {
+  return json(
+    { errorMessage },
+    {
+      headers: await flashMessage({
+        toast: { message: errorMessage, type: "error" },
+      }),
+    },
+  );
+}
 /**
  * Helper method used to redirect the user to a new page with a toast notification
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,46 +36,73 @@ async function redirectWithFlash(url: string, flash: FlashSessionValues, init?: 
   });
 }
 
-/**
- * Helper method used to display a success toast notification without redirection
- *
- * It need to be awaited
- * @param passedInData Generic object containing the data
- * @param toast Message to be shown as success
- * @param init Additional response options (status code, additional headers etc)
- * @returns Returns data and a toast cookie set
- */
-export async function jsonWithSuccess<T>(passedInData: T, toast: string, init?: ResponseInit) {
-  return json(
-    { ...passedInData, toast },
-    {
-      ...init,
-      headers: await flashMessage({
-        toast: { message: toast, type: "success" },
-      }),
-    },
-  );
+async function jsonWithFlash<T>(data: T, flash: FlashSessionValues, init?: ResponseInit) {
+  return json(data, {
+    ...init,
+    headers: await flashMessage(flash, init?.headers),
+  });
 }
+
 /**
- * Helper method used to display an error toast notification without redirection
+ * Helper method used to display a toast notification without redirection
  *
- * It need to be awaited
- * @param passedInData Generic object containing the data
- * @param toast Message to be shown as error
+ * @param data Generic object containing the data
+ * @param toast Toast message and it's type
  * @param init Additional response options (status code, additional headers etc)
- * @returns Returns data and a toast cookie set
+ * @returns Returns data with toast cookie set
  */
-export async function jsonWithError<T>(passedInData: T, toast: string, init?: ResponseInit) {
-  return json(
-    { ...passedInData, toast },
-    {
-      ...init,
-      headers: await flashMessage({
-        toast: { message: toast, type: "error" },
-      }),
-    },
-  );
+export function jsonWithToast<T>(data: T, toast: ToastMessage, init?: ResponseInit) {
+  return jsonWithFlash(data, { toast }, init);
 }
+
+/**
+ * Helper method used to generate a JSON response object with a success toast message.
+ *
+ * @param data The data to be included in the response.
+ * @param message The message for the success toast notification.
+ * @param init Additional response options (status code, additional headers etc)
+ * @returns Returns a JSON response object with the specified success toast message.
+ */
+export function jsonWithSuccess<T>(data: T, message: string, init?: ResponseInit) {
+  return jsonWithToast(data, { message, type: "success" }, init);
+}
+
+/**
+ * Helper method used to generate a JSON response object with an error toast message.
+ *
+ * @param data The data to be included in the response.
+ * @param message The message for the error toast notification.
+ * @param init Additional response options (status code, additional headers etc)
+ * @returns Returns a JSON response object with the specified error toast message.
+ */
+export function jsonWithError<T>(data: T, message: string, init?: ResponseInit) {
+  return jsonWithToast(data, { message, type: "error" }, init);
+}
+
+/**
+ * Helper method used to generate a JSON response object with an info toast message.
+ *
+ * @param data The data to be included in the response.
+ * @param message The message for the info toast notification.
+ * @param init Additional response options (status code, additional headers etc)
+ * @returns Returns a JSON response object with the specified info toast message.
+ */
+export function jsonWithInfo<T>(data: T, message: string, init?: ResponseInit) {
+  return jsonWithToast(data, { message, type: "info" }, init);
+}
+
+/**
+ * Helper method used to generate a JSON response object with a warning toast message.
+ *
+ * @param data The data to be included in the response.
+ * @param message The message for the warning toast notification.
+ * @param init Additional response options (status code, additional headers etc)
+ * @returns Returns a JSON response object with the specified warning toast message.
+ */
+export function jsonWithWarning<T>(data: T, message: string, init?: ResponseInit) {
+  return jsonWithToast(data, { message, type: "warning" }, init);
+}
+
 /**
  * Helper method used to redirect the user to a new page with a toast notification
  *

--- a/src/test-apps/testing-app/app/routes/_index.tsx
+++ b/src/test-apps/testing-app/app/routes/_index.tsx
@@ -1,5 +1,5 @@
 import type { MetaFunction } from "@remix-run/node";
-import { useSubmit } from "@remix-run/react";
+import { Link, useSubmit } from "@remix-run/react";
 import { redirectWithError } from "remix-toast";
 
 export const meta: MetaFunction = () => {
@@ -30,6 +30,9 @@ export default function Index() {
           <a target="_blank" href="https://remix.run/docs" rel="noreferrer">
             Remix Docs
           </a>
+        </li>
+        <li>
+          <Link to="/without-redirection">Test without redirection</Link>
         </li>
       </ul>
     </div>

--- a/src/test-apps/testing-app/app/routes/without-redirection.tsx
+++ b/src/test-apps/testing-app/app/routes/without-redirection.tsx
@@ -1,0 +1,63 @@
+import { cssBundleHref } from "@remix-run/css-bundle";
+import { DataFunctionArgs, type LinksFunction } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
+import { useEffect } from "react";
+import { displayErrorMessage, displaySuccessMessage } from "../../../../index";
+
+export const links: LinksFunction = () => [...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : [])];
+
+export async function action({ request }: DataFunctionArgs) {
+  const formData = await request.formData();
+  const messageType = formData.get("messageType");
+
+  switch (messageType) {
+    case "success":
+      return displaySuccessMessage("This is a success message");
+    case "error":
+      return displayErrorMessage("This is an error message");
+  }
+}
+
+export default function TestWithModals() {
+  const actionData = useActionData<typeof action>();
+
+  useEffect(() => {
+    if (actionData) {
+      if ("successMessage" in actionData) {
+        //Do something
+      }
+      if ("errorMessage" in actionData) {
+        //Do something
+      }
+    }
+  }, [actionData]);
+
+  return (
+    <div
+      style={{
+        fontFamily: "system-ui, sans-serif",
+        lineHeight: "1.8",
+        display: "flex",
+        flexDirection: "row",
+        gap: "120px",
+      }}
+    >
+      <div>
+        Test <b>success message</b> without redirection
+        <Form method="POST">
+          <button name="messageType" value="success" type="submit">
+            Click here
+          </button>
+        </Form>
+      </div>
+      <div>
+        Test <b>error message</b> without redirection
+        <Form method="POST">
+          <button name="messageType" value="error" type="submit">
+            Click here
+          </button>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/test-apps/testing-app/app/routes/without-redirection.tsx
+++ b/src/test-apps/testing-app/app/routes/without-redirection.tsx
@@ -2,7 +2,7 @@ import { cssBundleHref } from "@remix-run/css-bundle";
 import { DataFunctionArgs, type LinksFunction } from "@remix-run/node";
 import { Form, useActionData } from "@remix-run/react";
 import { useEffect } from "react";
-import { displayErrorMessage, displaySuccessMessage } from "../../../../index";
+import { jsonWithError, jsonWithSuccess } from "remix-toast";
 
 export const links: LinksFunction = () => [...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : [])];
 
@@ -12,9 +12,9 @@ export async function action({ request }: DataFunctionArgs) {
 
   switch (messageType) {
     case "success":
-      return displaySuccessMessage("This is a success message");
+      return jsonWithSuccess({},"This is a success message"); 
     case "error":
-      return displayErrorMessage("This is an error message");
+      return jsonWithError({}, "This is an error message");
   }
 }
 
@@ -23,10 +23,7 @@ export default function TestWithModals() {
 
   useEffect(() => {
     if (actionData) {
-      if ("successMessage" in actionData) {
-        //Do something
-      }
-      if ("errorMessage" in actionData) {
+      if ("toast" in actionData) {
         //Do something
       }
     }

--- a/src/test-apps/testing-app/app/routes/without-redirection.tsx
+++ b/src/test-apps/testing-app/app/routes/without-redirection.tsx
@@ -1,8 +1,7 @@
 import { cssBundleHref } from "@remix-run/css-bundle";
 import { DataFunctionArgs, type LinksFunction } from "@remix-run/node";
-import { Form, useActionData } from "@remix-run/react";
-import { useEffect } from "react";
-import { jsonWithError, jsonWithSuccess } from "remix-toast";
+import { Form } from "@remix-run/react";
+import { jsonWithError, jsonWithInfo, jsonWithSuccess, jsonWithWarning } from "remix-toast";
 
 export const links: LinksFunction = () => [...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : [])];
 
@@ -10,50 +9,78 @@ export async function action({ request }: DataFunctionArgs) {
   const formData = await request.formData();
   const messageType = formData.get("messageType");
 
+  // The empty object passed as the first argument can be used
+  // to include additional data to be returned along with the toasters.
   switch (messageType) {
     case "success":
-      return jsonWithSuccess({},"This is a success message"); 
+      return jsonWithSuccess({}, "This is a success message");
     case "error":
       return jsonWithError({}, "This is an error message");
+    case "info":
+      return jsonWithInfo({}, "This is an info");
+    case "warning":
+      return jsonWithWarning({}, "This is a warning");
   }
 }
 
-export default function TestWithModals() {
-  const actionData = useActionData<typeof action>();
-
-  useEffect(() => {
-    if (actionData) {
-      if ("toast" in actionData) {
-        //Do something
-      }
-    }
-  }, [actionData]);
-
+export default function TestWithoutRedirection() {
   return (
     <div
       style={{
         fontFamily: "system-ui, sans-serif",
         lineHeight: "1.8",
         display: "flex",
-        flexDirection: "row",
+        flexDirection: "column",
         gap: "120px",
       }}
     >
-      <div>
-        Test <b>success message</b> without redirection
-        <Form method="POST">
-          <button name="messageType" value="success" type="submit">
-            Click here
-          </button>
-        </Form>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          gap: "120px",
+        }}
+      >
+        <div>
+          Test <b>success message</b> without redirection
+          <Form method="POST">
+            <button name="messageType" value="success" type="submit">
+              Click here
+            </button>
+          </Form>
+        </div>
+        <div>
+          Test <b>error message</b> without redirection
+          <Form method="POST">
+            <button name="messageType" value="error" type="submit">
+              Click here
+            </button>
+          </Form>
+        </div>
       </div>
-      <div>
-        Test <b>error message</b> without redirection
-        <Form method="POST">
-          <button name="messageType" value="error" type="submit">
-            Click here
-          </button>
-        </Form>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          gap: "120px",
+        }}
+      >
+        <div>
+          Test <b>warning message</b> without redirection
+          <Form method="POST">
+            <button name="messageType" value="warning" type="submit">
+              Click here
+            </button>
+          </Form>
+        </div>
+        <div>
+          Test <b>info message</b> without redirection
+          <Form method="POST">
+            <button name="messageType" value="info" type="submit">
+              Click here
+            </button>
+          </Form>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #3 #4

# Description

This pull request introduces a significant enhancement to the existing functionality of the library. The core feature of the library was initially centered around displaying message toasts with redirection. However, with this contribution, we've expanded the capabilities to provide users with the flexibility to showcase error or success messages without triggering a redirection.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [ ] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules