### PR TITLE
Proposal: customise toast session cookie options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-toast",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-toast",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "workspaces": [
         "src/test-apps/testing-app",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { sign, unsign } from "./crypto";
 const FLASH_SESSION = "flash";
 const createCookie = createCookieFactory({ sign, unsign });
 
-export type ToastCookieOptions = Partial<SessionIdStorageStrategy["cookie"]>;
+type ToastCookieOptions = Partial<SessionIdStorageStrategy["cookie"]>;
 
 const toastCookieOptions = {
   name: "toast-session",
@@ -208,4 +208,4 @@ export async function getToast(request: Request): Promise<{ toast: ToastMessage 
   return { toast, headers };
 }
 
-export type { ToastMessage };
+export type { ToastMessage, ToastCookieOptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,39 @@
-import { createCookieSessionStorageFactory, createCookieFactory, redirect, json } from "@remix-run/server-runtime";
+import {
+  createCookieSessionStorageFactory,
+  createCookieFactory,
+  redirect,
+  json,
+  SessionIdStorageStrategy,
+} from "@remix-run/server-runtime";
 import { FlashSessionValues, ToastMessage, flashSessionValuesSchema } from "./schema";
 import { sign, unsign } from "./crypto";
 
 const FLASH_SESSION = "flash";
 const createCookie = createCookieFactory({ sign, unsign });
 
+type ToastCookieOptions = Partial<SessionIdStorageStrategy["cookie"]>;
+
+const toastCookieOptions = {
+  name: "toast-session",
+  sameSite: "lax",
+  path: "/",
+  httpOnly: true,
+  secrets: ["s3Cr3t"],
+} satisfies ToastCookieOptions;
+
 const sessionStorage = createCookieSessionStorageFactory(createCookie)({
-  cookie: {
-    name: "toast-session",
-    sameSite: "lax",
-    path: "/",
-    httpOnly: true,
-    secrets: ["s3Cr3t"],
-  },
+  cookie: toastCookieOptions,
 });
+
+export function setToastCookieOptions(customOptions: ToastCookieOptions) {
+  Object.assign(toastCookieOptions, customOptions);
+  Object.assign(
+    sessionStorage,
+    createCookieSessionStorageFactory(createCookie)({
+      cookie: toastCookieOptions,
+    }),
+  );
+}
 
 function getSessionFromRequest(request: Request) {
   const cookie = request.headers.get("Cookie");

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,13 @@ const sessionStorage = createCookieSessionStorageFactory(createCookie)({
   cookie: toastCookieOptions,
 });
 
-export function setToastCookieOptions(customOptions: ToastCookieOptions) {
-  Object.assign(toastCookieOptions, customOptions);
+/**
+ * Sets the cookie options to be used for the toast cookie
+ *
+ * @param options Cookie options to be used for the toast cookie
+ */
+export function setToastCookieOptions(options: ToastCookieOptions) {
+  Object.assign(toastCookieOptions, options);
   Object.assign(
     sessionStorage,
     createCookieSessionStorageFactory(createCookie)({

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { sign, unsign } from "./crypto";
 const FLASH_SESSION = "flash";
 const createCookie = createCookieFactory({ sign, unsign });
 
-type ToastCookieOptions = Partial<SessionIdStorageStrategy["cookie"]>;
+export type ToastCookieOptions = Partial<SessionIdStorageStrategy["cookie"]>;
 
 const toastCookieOptions = {
   name: "toast-session",

--- a/src/test-apps/testing-app/app/root.tsx
+++ b/src/test-apps/testing-app/app/root.tsx
@@ -1,9 +1,11 @@
 import { json, type LinksFunction, type LoaderFunctionArgs } from "@remix-run/node";
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
 import { useEffect } from "react";
-import { getToast } from "remix-toast";
+import { getToast, setToastCookieOptions } from "remix-toast";
 import { ToastContainer, toast as notify } from "react-toastify";
 import toastStyles from "react-toastify/dist/ReactToastify.css";
+
+setToastCookieOptions({ name: "toast-custom-session" });
 
 export const links: LinksFunction = () => [{ rel: "stylesheet", href: toastStyles }];
 


### PR DESCRIPTION
# Description

Enable custom cookie options.

## API proposal
A `setToastCookieOptions` to use (optional) in your `root.tsx`.
```ts
import { getToast, setToastCookieOptions } from "remix-toast";

setToastCookieOptions({ name: "toast-custom-session" });
```
This function takes a `Partial<SessionIdStorageStrategy["cookie"]>` (from `@remix-run/server-runtime`), the same options as `createCookieSessionStorage`.
You can customise every options, they will be merged with the default build-it (`toastCookieOptions`)

```ts
export type ToastCookieOptions = Partial<SessionIdStorageStrategy["cookie"]>;

const toastCookieOptions = {
  name: "toast-session",
  sameSite: "lax",
  path: "/",
  httpOnly: true,
  secrets: ["s3Cr3t"],
} satisfies ToastCookieOptions;
```

Fixes https://github.com/Code-Forge-Net/remix-toast/issues/5

If this is a new feature please add a description of what was added and why below:


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules